### PR TITLE
Tanzeela/add keystone

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -11,6 +11,7 @@ const requestify = require('requestify');
 
 const numberOfFBPosts = 7;
 const numberOfTUMBLRPosts = 3;
+const KEYSTONE = 'http://localhost:3010/api/articles/?list';
 const FB = `https://graph.facebook.com/uclaradio?fields=posts.limit(${numberOfFBPosts}){full_picture,message,created_time,link}&access_token=${
   passwords.FB_API_KEY
 }`;
@@ -28,6 +29,23 @@ router.get('/blurbinfo', (req, res, next) => {
     res.setHeader('Content-Type', 'application/json');
     res.send(JSON.stringify(blurb));
   });
+});
+
+router.get('/getArticles', (req, res) => {
+  requestify
+    .get(KEYSTONE, {
+      cache: {
+        cache: true,
+        expires: 100000000,
+      },
+    })
+    .then(response => {
+      const data = response.getBody();
+      res.send(data.articles);
+    })
+    .fail(response => {
+      console.log(response);
+    });
 });
 
 router.get('/getSocialMedia', (req, res) => {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -11,7 +11,7 @@ const requestify = require('requestify');
 
 const numberOfFBPosts = 7;
 const numberOfTUMBLRPosts = 3;
-const KEYSTONE = 'http://localhost:3010/api/articles/?list';
+const KEYSTONE = 'http://localhost:3010/api/articles';
 const FB = `https://graph.facebook.com/uclaradio?fields=posts.limit(${numberOfFBPosts}){full_picture,message,created_time,link}&access_token=${
   passwords.FB_API_KEY
 }`;
@@ -29,6 +29,24 @@ router.get('/blurbinfo', (req, res, next) => {
     res.setHeader('Content-Type', 'application/json');
     res.send(JSON.stringify(blurb));
   });
+});
+
+router.get('/getArticles/:blogPostID', function(req, res) {
+  var queryAPI = `${KEYSTONE}/${req.params.blogPostID}`;
+  requestify
+    .get(queryAPI, {
+      cache: {
+        cache: true,
+        expires: 100000000,
+      },
+    })
+    .then(response => {
+      const data = response.getBody();
+      res.send(data);
+    })
+    .fail(response => {
+      console.log(response);
+    });
 });
 
 router.get('/getArticles', (req, res) => {

--- a/client/react/frontpage/Frontpage.js
+++ b/client/react/frontpage/Frontpage.js
@@ -39,6 +39,7 @@ import PromoBanner from './components/PromoBanner';
 import RectImage from '../common/RectImage';
 
 import './frontpage.scss';
+import BlogPostPage from './components/BlogPostPage';
 
 // Google analytics helper
 
@@ -178,6 +179,7 @@ const routes = (
     <Route path="/shows" components={ShowsContent} />
     <Route path="/shows/:showID" component={ShowPage} />
     <Route path="/blog" component={BlogPage} />
+    <Route path="blog/:blogPostID" component={BlogPostPage} />
     <Route path="/events/:eventID" component={EventPage} />
     <Route path="/streamIssues" component={StreamIssuesPage} />
     <Route path="/about" component={AboutPage} />

--- a/client/react/frontpage/components/BlogPage.js
+++ b/client/react/frontpage/components/BlogPage.js
@@ -2,127 +2,62 @@
 // shows full description of a show
 
 import React from 'react';
-const axios = require('axios');
 /**
 Page content for individual show
 Displays full description of a show, with blurb, picture, djs.. everything
 
-@prop show: show object
 @prop fetching: currently fetching shows
-@prop updateShows: callback to update all listed shows
 * */
 
-const AddPost = React.createClass({
-  getInitialState: function() {
-    return {
-      title: '',
-      content: '',
-    };
-  },
+const keystoneAPI = '/getArticles';
+const keystoneURL = 'http://localhost:3010/';
 
-  handleTitleChange(e) {
-    this.setState({ title: e.target.value });
-  },
-  handleContentChange(e) {
-    this.setState({ content: e.target.value });
-  },
-  addPost() {
-    axios
-      .post('/addPost', {
-        title: this.state.title,
-        content: this.state.content,
-      })
-      .then(function(response) {
-        console.log('response from add post is ', response);
-        console.log('Hi i am in BlogPage');
-      })
-      .catch(function(error) {
-        console.log(error);
-      });
-  },
-
-  render() {
-    return (
-      <div className="col-md-5">
-        <div className="form-area">
-          <form role="form">
-            <br styles="clear:both" />
-            <div className="Unit">
-              <div className="form-group">
-                <input
-                  type="text"
-                  onChange={this.handleTitleChange}
-                  className="form-control"
-                  id="title"
-                  name="title"
-                  placeholder="Title"
-                  required
-                />
-              </div>
-
-              <div className="form-group" id="textbox">
-                <textarea
-                  className="form-control"
-                  onChange={this.handleContentChange}
-                  type="textarea"
-                  id="content"
-                  placeholder="Subject"
-                  maxLength="2000000000"
-                  rows="10"
-                />
-              </div>
-              <div className="button-align">
-                <button
-                  type="button"
-                  id="submit"
-                  name="submit"
-                  className="btn btn-primary pull-right"
-                  onClick={this.addPost}
-                >
-                  Add Post
-                </button>
-              </div>
-            </div>
-          </form>
-        </div>
-      </div>
-    );
-  },
-});
 const BlogPage = React.createClass({
   getInitialState: function() {
-    return { count: 'Hello!' };
+    return { blogPosts: [] };
   },
   componentDidMount() {
-    // scroll to top of page
-    document.body.scrollTop = document.documentElement.scrollTop = 0;
+    $.get(keystoneAPI, articles => {
+      this.setState({ blogPosts: articles });
+    });
   },
-
-  handleClick(e) {
-    this.setState({ count: 1 });
-
-    console.log('hi');
+  renderArticles() {
+    const data = Object.values(this.state.blogPosts);
+    return data.map(article => {
+      console.log('article');
+      console.log(article);
+      const img = article.image ? article.image.filename : '';
+      // Get the html for content
+      function createMarkupForContent() {
+        if (article.content) {
+          return {
+            __html: article.content,
+          };
+        } else {
+          return;
+        }
+      }
+      if ((article.state = 'published')) {
+        return (
+          <div key={article._id}>
+            <h1>{article.name}</h1>
+            <img
+              style={{ width: '300px', height: '300px' }}
+              src={keystoneURL + img}
+            />
+            <h2>Content</h2>
+            <div dangerouslySetInnerHTML={createMarkupForContent()} />
+          </div>
+        );
+      }
+    });
   },
-  // creates readable string from DJ dictionary returned from the server
-
   render() {
-    return (
-      <div>
-        <button
-          onClick={this.handleClick}
-          type="button"
-          id="submit"
-          name="submit"
-          className="btn btn-primary pull-right"
-        >
-          Create a Post
-        </button>
-        ,{this.state.count === 1 && <AddPost />}
-      </div>
-    );
+    if (this.state.blogPosts) {
+      return <div>{this.renderArticles()}</div>;
+    }
+    return <div>Loading</div>;
   },
 });
-
-// set show if found
 
 export default BlogPage;

--- a/client/react/frontpage/components/BlogPage.js
+++ b/client/react/frontpage/components/BlogPage.js
@@ -1,12 +1,12 @@
-// ShowPage.js
+// BlogPage.js
 // shows full description of a show
 
 import React from 'react';
+import { Link } from 'react-router';
 /**
 Page content for individual show
 Displays full description of a show, with blurb, picture, djs.. everything
 
-@prop fetching: currently fetching shows
 * */
 
 const keystoneAPI = '/getArticles';
@@ -21,11 +21,12 @@ const BlogPage = React.createClass({
       this.setState({ blogPosts: articles });
     });
   },
+  urlFromBlogPost(blogPost) {
+    return `/blog/${blogPost._id}`;
+  },
   renderArticles() {
     const data = Object.values(this.state.blogPosts);
     return data.map(article => {
-      console.log('article');
-      console.log(article);
       const img = article.image ? article.image.filename : '';
       // Get the html for content
       function createMarkupForContent() {
@@ -40,7 +41,9 @@ const BlogPage = React.createClass({
       if ((article.state = 'published')) {
         return (
           <div key={article._id}>
-            <h1>{article.name}</h1>
+            <Link to={this.urlFromBlogPost(article)}>
+              <h1>{article.name}</h1>
+            </Link>
             <img
               style={{ width: '300px', height: '300px' }}
               src={keystoneURL + img}

--- a/client/react/frontpage/components/BlogPage.js
+++ b/client/react/frontpage/components/BlogPage.js
@@ -1,16 +1,16 @@
 // BlogPage.js
-// shows full description of a show
+// Blog page
 
 import React from 'react';
 import { Link } from 'react-router';
+import Loader from './Loader';
 /**
-Page content for individual show
-Displays full description of a show, with blurb, picture, djs.. everything
-
+Page content for all blog posts. 
+Displays shortened descriptions for each post
 * */
 
 const keystoneAPI = '/getArticles';
-const keystoneURL = 'http://localhost:3010/';
+const keystoneURL = 'http://localhost:3010';
 
 const BlogPage = React.createClass({
   getInitialState: function() {
@@ -45,8 +45,9 @@ const BlogPage = React.createClass({
               <h1>{article.name}</h1>
             </Link>
             <img
+              alt="blog post image"
               style={{ width: '300px', height: '300px' }}
-              src={keystoneURL + img}
+              src={keystoneURL + '/' + img}
             />
             <h2>Content</h2>
             <div dangerouslySetInnerHTML={createMarkupForContent()} />
@@ -56,10 +57,14 @@ const BlogPage = React.createClass({
     });
   },
   render() {
-    if (this.state.blogPosts) {
-      return <div>{this.renderArticles()}</div>;
+    if (!this.state.blogPosts) {
+      return (
+        <div className="blogPage">
+          {this.props.fetching ? <Loader /> : 'No blog posts!'}
+        </div>
+      );
     }
-    return <div>Loading</div>;
+    return <div className="blogPage">{this.renderArticles()}</div>;
   },
 });
 

--- a/client/react/frontpage/components/BlogPostPage.js
+++ b/client/react/frontpage/components/BlogPostPage.js
@@ -1,22 +1,19 @@
-// BlogPostInfo.js
-// shows full description of a show
+// BlogPostPage.js
+// shows full description of post
 
 import React from 'react';
 import Loader from './Loader';
 /**
-Page content for individual show
-Displays full description of a show, with blurb, picture, djs.. everything
+Page content for individual post
+Displays full description of a post.. everything
 * */
 
 const keystoneAPI = '/getArticles';
-const keystoneURL = 'http://localhost:3010/';
+const keystoneURL = 'http://localhost:3010';
 
 const BlogPostPage = React.createClass({
   getInitialState: function() {
     return { blogPost: null };
-  },
-  urlFromBlogPost(blogPost) {
-    return `/blog/${blogPost._id}`;
   },
   componentDidMount() {
     var queryRoute = `${keystoneAPI}/${this.props.params.blogPostID}`;
@@ -48,8 +45,9 @@ const BlogPostPage = React.createClass({
         <div key={blogPost._id}>
           <h1>{blogPost.name}</h1>
           <img
+            alt="blog post image"
             style={{ width: '300px', height: '300px' }}
-            src={keystoneURL + img}
+            src={keystoneURL + '/' + img}
           />
           <h2>Content</h2>
           <div dangerouslySetInnerHTML={this.createMarkupForContent()} />

--- a/client/react/frontpage/components/BlogPostPage.js
+++ b/client/react/frontpage/components/BlogPostPage.js
@@ -1,0 +1,62 @@
+// BlogPostInfo.js
+// shows full description of a show
+
+import React from 'react';
+import Loader from './Loader';
+/**
+Page content for individual show
+Displays full description of a show, with blurb, picture, djs.. everything
+* */
+
+const keystoneAPI = '/getArticles';
+const keystoneURL = 'http://localhost:3010/';
+
+const BlogPostPage = React.createClass({
+  getInitialState: function() {
+    return { blogPost: null };
+  },
+  urlFromBlogPost(blogPost) {
+    return `/blog/${blogPost._id}`;
+  },
+  componentDidMount() {
+    var queryRoute = `${keystoneAPI}/${this.props.params.blogPostID}`;
+    $.get(queryRoute, article => {
+      this.setState({ blogPost: article });
+    });
+  },
+  createMarkupForContent() {
+    if (this.state.blogPost.content) {
+      return {
+        __html: this.state.blogPost.content,
+      };
+    } else {
+      return;
+    }
+  },
+  render() {
+    if (!this.state.blogPost) {
+      return (
+        <div className="blogPostPage">
+          {this.props.fetching ? <Loader /> : "This post doesn't exist!"}
+        </div>
+      );
+    }
+    const blogPost = this.state.blogPost;
+    const img = blogPost.image ? blogPost.image.filename : '';
+    return (
+      <div className="blogPostPage">
+        <div key={blogPost._id}>
+          <h1>{blogPost.name}</h1>
+          <img
+            style={{ width: '300px', height: '300px' }}
+            src={keystoneURL + img}
+          />
+          <h2>Content</h2>
+          <div dangerouslySetInnerHTML={this.createMarkupForContent()} />
+        </div>
+      </div>
+    );
+  },
+});
+
+export default BlogPostPage;


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
Instead building our own CMS from scratch (bc that's kind of crazy), we are using Keystone! Keystone is setup here: [uclaradio-blog](https://github.com/uclaradio/uclaradio-blog)
Todo: Need to add redux instead of using get request api calls ;-;

## Approach
Disclaimer: Keystone API gives "articles", but we call them "blogPosts" in uclaradio.com. This inconsistency needs to be resolved but I'm super indecisive, please help me choose. 

`app/routes/index.js`
Setup routes `/getArticles/:blogPostID` and `/getArticles` which make get requests to the Keystone API. Format is similar to the '/getSocialMedia' route. 

`client/react/frontpage/components/BlogPage.js`
Removed old code and essentially replaced it with the [Keystone frontend client code](https://github.com/uclaradio/uclaradio-blog/blob/master/client/containers/RecipeList.jsx). We will not be using the Keystone frontend, we'll be making API calls to Keystone's backend to render the objects on uclaradio.com's frontend.
`componentDidMount()` makes a get request to our newly defined route `/getArticles/`. Once the articles are received from the API, they are passed into the global state variable `blogPosts`. 
`renderArticles()` called from render(), the old Keystone code that uses the `blogPosts` object to render all the articles. The HTML template includes a link to the article page itself.

`client/react/frontpage/Frontpage.js`
I added a new route to "blog/:blogPostID" which uses the `BlogPostPage` component.

`client/react/frontpage/components/BlogPostPage.js`
`componentDidMount()` makes a get request to our newly defined route `/getArticles/:blogPostID`. Once the single article is received from the API, it is passed into a global variable `blogPost`. 
`render()`I render the deets from `blogPost` variable.

## Learning
Need to redo the API calling using redux!! 
[Query an object in Keystone](https://github.com/keystonejs/keystone/issues/1836)

## Checklist

- [ ] My branch follows the branch naming scheme of UCLA Radio, and can merge into `master` without error.
- [x] My code follows the code style of this project, and I have linted it to confirm this.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] All new and existing tests passed.