### PR TITLE
Tanzeela/combine tumblr

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -9,7 +9,7 @@ const passwords = require('../../passwords');
 const requestify = require('requestify');
 
 const numberOfFBPosts = 7;
-const numberOfTUMBLRPosts = 3;
+const numberOfTUMBLRPosts = 10;
 const keystoneIDLength = 24;
 const tumblrIDLength = 12;
 const KEYSTONE = 'http://localhost:3010/api/posts';

--- a/client/react/frontpage/components/BlogPage.js
+++ b/client/react/frontpage/components/BlogPage.js
@@ -9,7 +9,7 @@ Page content for all blog posts.
 Displays shortened descriptions for each post
 * */
 
-const keystoneAPI = '/getBlogPosts';
+const BlogPostsURL = '/getBlogPosts';
 const keystoneURL = 'http://localhost:3010';
 
 const BlogPage = React.createClass({
@@ -17,17 +17,15 @@ const BlogPage = React.createClass({
     return { posts: [], fetching: true };
   },
   componentDidMount() {
-    $.get(keystoneAPI, posts => {
-      this.setState({ fetching: false, posts: posts });
+    $.get(BlogPostsURL, result => {
+      this.setState({ fetching: false, posts: result.blog_posts });
     });
   },
   urlFromPost(post) {
-    return `/blog/${post._id}`;
+    return `/blog/${post.id}`;
   },
   renderPosts() {
-    const data = Object.values(this.state.posts);
-    return data.map(post => {
-      const img = post.image ? post.image.filename : '';
+    return this.state.posts.map(post => {
       // Get the html for content
       function createMarkupForContent() {
         if (post.content) {
@@ -38,21 +36,33 @@ const BlogPage = React.createClass({
           return;
         }
       }
-      if ((post.state = 'published')) {
-        return (
-          <div key={post._id}>
-            <Link to={this.urlFromPost(post)}>
-              <h1>{post.name}</h1>
-            </Link>
-            <img
-              alt="post image"
-              style={{ width: '300px', height: '300px' }}
-              src={keystoneURL + '/' + img}
-            />
-            <h2>Content</h2>
-            <div dangerouslySetInnerHTML={createMarkupForContent()} />
-          </div>
-        );
+      switch (post.platform) {
+        case 'KEYSTONE':
+          const img = post.image ? post.image.filename : '';
+          return (
+            <div key={post.id}>
+              <Link to={this.urlFromPost(post)}>
+                <h1>{post.title}</h1>
+              </Link>
+              <img
+                alt="post image"
+                style={{ width: '300px', height: '300px' }}
+                src={keystoneURL + '/' + img}
+              />
+              <h2>Content</h2>
+              <div dangerouslySetInnerHTML={createMarkupForContent()} />
+            </div>
+          );
+        case 'TUMBLR':
+          return (
+            <div key={post.id}>
+              <Link to={this.urlFromPost(post)}>
+                <h1>{post.title}</h1>
+              </Link>
+              <h2>Content</h2>
+              <div dangerouslySetInnerHTML={createMarkupForContent()} />
+            </div>
+          );
       }
     });
   },

--- a/client/react/frontpage/components/BlogPostPage.js
+++ b/client/react/frontpage/components/BlogPostPage.js
@@ -8,7 +8,7 @@ Page content for individual post
 Displays full description of a post.. everything
 * */
 
-const keystoneAPI = '/getBlogPosts';
+const BlogPostsURL = '/getBlogPosts';
 const keystoneURL = 'http://localhost:3010';
 
 const BlogPostPage = React.createClass({
@@ -16,7 +16,7 @@ const BlogPostPage = React.createClass({
     return { fetching: true, post: null };
   },
   componentDidMount() {
-    var queryRoute = `${keystoneAPI}/${this.props.params.blogPostID}`;
+    var queryRoute = `${BlogPostsURL}/${this.props.params.blogPostID}`;
     $.get(queryRoute, post => {
       this.setState({ fetching: false, post: post });
     });
@@ -30,6 +30,33 @@ const BlogPostPage = React.createClass({
       return;
     }
   },
+  renderPost() {
+    const post = this.state.post;
+    switch (post.platform) {
+      case 'KEYSTONE':
+        const img = post.image ? post.image.filename : '';
+        return (
+          <div key={post.id}>
+            <h1>{post.title}</h1>
+            <img
+              alt="post image"
+              style={{ width: '300px', height: '300px' }}
+              src={keystoneURL + '/' + img}
+            />
+            <h2>Content</h2>
+            <div dangerouslySetInnerHTML={this.createMarkupForContent()} />
+          </div>
+        );
+      case 'TUMBLR':
+        return (
+          <div key={post.id}>
+            <h1>{post.title}</h1>
+            <h2>Content</h2>
+            <div dangerouslySetInnerHTML={this.createMarkupForContent()} />
+          </div>
+        );
+    }
+  },
   render() {
     if (!this.state.post) {
       return (
@@ -38,22 +65,7 @@ const BlogPostPage = React.createClass({
         </div>
       );
     }
-    const post = this.state.post;
-    const img = post.image ? post.image.filename : '';
-    return (
-      <div className="blogPostPage">
-        <div key={post._id}>
-          <h1>{post.name}</h1>
-          <img
-            alt="post image"
-            style={{ width: '300px', height: '300px' }}
-            src={keystoneURL + '/' + img}
-          />
-          <h2>Content</h2>
-          <div dangerouslySetInnerHTML={this.createMarkupForContent()} />
-        </div>
-      </div>
-    );
+    return <div className="blogPostPage">{this.renderPost()}</div>;
   },
 });
 

--- a/uclaradio-blog/.gitignore
+++ b/uclaradio-blog/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+node_modules/

--- a/uclaradio-blog/.gitignore
+++ b/uclaradio-blog/.gitignore
@@ -1,2 +1,0 @@
-package-lock.json
-node_modules/


### PR DESCRIPTION
<!--- Be sure to add a descriptive title above! -->

## Types of changes
- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
[Issue #263](https://github.com/uclaradio/uclaradio.com/issues/263)
Now you can see the real tumblr posts in the blog pages! They are combined with the newly made Keystone posts. 

## Approach
**`app/routes/index.js`**
I updated the routes for "/getBlogPosts" and "/getBlogPosts/:blogPostID" to also include tumblr posts.

"/getBlogPosts" now gets Tumblr posts, but also modifies the post objects to make the post objects for tumblr and keystone uniformly usable in the Frontend. Namely, `post.id`, `post.platform`, `post.created_time`, `post.title`, `post.content` are modified.

"/getBlogPosts/:blogPostID" is kinda weird. 

When you call this route, the only parameter is `blogPostID`, so you can't tell if the post is from Tumblr or Keystone. If you don't know the source, you don't know which API to query for the actual post. 
These are the meh approaches I thought of:
- Add a second parameter to the route that specifies the platform (tumblr/keystone). I thought this would be too much work for the frontend, but it's probably more correct now that I think about it lol
- Store all the tumblr and keystone posts in the uclaradio.com backend. We'd have to make it global property of the frontend using redux. This seemed incorrect, I don't think you should be storing the database of an API. 
- **Selected:** Keystone and Tumblr ids are different lengths (24 vs 12). This is a dumb simple way to differentiate the source of the id, but probably isn't sustainable. This totally hides the id issue from the frontend.

Another issue. I can't figure out how the query the tumblr API by ID. [Tumblr API has a way of doing so](https://www.tumblr.com/docs/en/api/v2#postspost-id---fetching-a-post-neue-post-format), but I get an authentication error when I attempt to query this route. So, I had two options.
- Store the entire tumblr database in the backend and connect it to Frontend using redux. Then, create our own getByID routes for our stored tumblr database. As explained before, this is a bad solution.
- **Selected:** Fetch all the tumblr posts and filter by ID. This solution is bad too because you have to fetch all the posts.

**`client/react/frontpage/components/BlogPage.js`**
I added a case statement for publishing tumblr posts. The format is slightly different. You need to add an image as a separate div for Keystone, and is not necessary for Tumblr. 

**`client/react/frontpage/components/BlogPostPage.js`**
Changes similar to those of BlogPage.js 

## Screenshot(s) 
<img width="990" alt="screen shot 2018-12-24 at 6 43 43 pm" src="https://user-images.githubusercontent.com/22732325/50410142-e6883900-07ab-11e9-9d2b-1fe834e2f3f1.png">
<img width="989" alt="screen shot 2018-12-24 at 6 43 48 pm" src="https://user-images.githubusercontent.com/22732325/50410143-e6883900-07ab-11e9-9bac-f9cd9ab8f475.png">

## Checklist
- [ ] My branch follows the branch naming scheme of UCLA Radio, and can merge into `master` without error.
- [x] My code follows the code style of this project, and I have linted it to confirm this.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] All new and existing tests passed.