### PR TITLE
override blogpostpage formatting

### DIFF
--- a/client/react/frontpage/components/BlogPostPage.scss
+++ b/client/react/frontpage/components/BlogPostPage.scss
@@ -12,6 +12,13 @@
 .content {
   font-size: 17px;
   line-height: 1.7;
+  margin: 10px 0;
+}
+
+// Override Keystone Formatting
+.content * {
+  background-color: transparent !important;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif !important;
 }
 
 .content > img,


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to **not** work as expected)

## Purpose

Make formatting uniform on the blog. KeystoneJS sometimes changes the font-family and the background of the text in the `post.content` object. This content is directly displayed on radio, so we decided to override formatting on this end. 

## Approach

I added `.content *` and attached `!important` to override Keystone formatting. 

## Screenshot(s)

Before:
<img width="858" alt="Screen Shot 2019-03-11 at 10 40 38 AM" src="https://user-images.githubusercontent.com/22732325/54145054-58a30e00-43ea-11e9-97a6-779689f0a4f5.png">

After:
<img width="571" alt="Screen Shot 2019-03-11 at 10 42 27 AM" src="https://user-images.githubusercontent.com/22732325/54145068-648ed000-43ea-11e9-83d5-06df57942ff5.png">


## Checklist

- [x] My branch follows the branch naming scheme of UCLA Radio, and can merge into `master` without error.
- [x] My code follows the code style of this project, and I have linted it to confirm this.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] All new and existing tests passed.

## Link to Issue

[#356](https://github.com/uclaradio/uclaradio.com/issues/356)
