### PR TITLE
Added Google Analytics global site tag

### DIFF
--- a/client/public/frontpage.html
+++ b/client/public/frontpage.html
@@ -29,6 +29,16 @@
   <!-- React Slider Styles -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css">
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-55657708-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-55657708-1');
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
<!--- Be sure to add a descriptive title above! -->

## Types of changes

<!--- What types of changes does your code introduce to UCLA Radio? Put an `x` in the boxes that apply. -->

- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to **not** work as expected)

## Purpose

<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Turns out our website is not configured for Google Site Analytics! According to the admin dashboard, we need to add a tag to the website so that Analytics can pick up data.