### PR TITLE
Update links to festival and show request forms

### DIFF
--- a/app/services/mail.js
+++ b/app/services/mail.js
@@ -51,7 +51,7 @@ mail.resetPassword = function(email, token) {
 mail.send = function(to, subject, body) {
   // setup e-mail data with unicode symbols
   const mailOptions = {
-    from: '"UCLA Radio Dev Dept." <radio.web@media.ucla.edu>',
+    from: '"UCLA Radio Dev Dept." <radio.dev@media.ucla.edu>',
     to,
     subject,
     text: body,

--- a/client/public/css/pages.css
+++ b/client/public/css/pages.css
@@ -43,7 +43,7 @@ body {
 }
 
 .demo-card-wide > .mdl-card__title.festival-press {
-  background: url("/img/festival-form.jpg") center / cover;
+  background: url("/img/festival-form.jpeg") center / cover;
 }
 
 .demo-card-wide > .mdl-card__title.substitution {

--- a/client/views/pages.jade
+++ b/client/views/pages.jade
@@ -90,9 +90,9 @@ head
             .mdl-card__title.concert-press
               h2.mdl-card__title-text Tickets & Press Request Form
             .mdl-card__supporting-text
-              | Want to go to a show for free? Fill this out.
+              | Want to go to a show for free? Check this out.
             .mdl-card__actions.mdl-card--border
-              a.mdl-button.mdl-button--colored.mdl-js-button.mdl-js-ripple-effect(target='_blank', href='https://bit.ly/1y1gPtt')
+              a.mdl-button.mdl-button--colored.mdl-js-button.mdl-js-ripple-effect(target='_blank', href='https://sites.google.com/view/digipressuclaradio/covering-shows?authuser=0')
                 | Go
 
         .col-md-4
@@ -102,7 +102,7 @@ head
             .mdl-card__supporting-text
               | Wanna go to a festival? Let us know!
             .mdl-card__actions.mdl-card--border
-              a.mdl-button.mdl-button--colored.mdl-js-button.mdl-js-ripple-effect(target='_blank', href='https://docs.google.com/forms/d/e/1FAIpQLSdMp8-MkL9ehNi7fTTC0ROfmY6kJ6eeZwpp9owHpZePBnkrPA/viewform')
+              a.mdl-button.mdl-button--colored.mdl-js-button.mdl-js-ripple-effect(target='_blank', href='https://sites.google.com/view/digipressuclaradio/covering-shows/request-festival-coverage?authuser=0')
                 | Go
 
       .row


### PR DESCRIPTION
By request from DigiPress, this PR changes the links for festival and show request forms to point to the [new DigiPress website](https://sites.google.com/view/digipressuclaradio/home)

Note: One of the commits updates an unrelated file, `mail.js`. That's just a small update that changes the email address provided in email bodies from radio.web@media.ucla.edu to radio.dev@media.ucla.edu. It's a minor enough change that I didn't think it warranted its own branch.